### PR TITLE
fix(qt5): support for Qt5 and QGIS 3.22

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -26,6 +26,8 @@
 
 """
 
+
 def classFactory(iface):
-    from newmemorylayer import NewMemoryLayer
+    from .newmemorylayer import NewMemoryLayer
+
     return NewMemoryLayer(iface)

--- a/metadata.txt
+++ b/metadata.txt
@@ -22,8 +22,9 @@ about[pl]=Wtyczka tworzy w pamięci nową warstwę w dwóch prostych kliknięcia
       znajduje się na pasku narzędzi Warstwa oraz w menu Warstwa -> Utwórz nową
       warstwę. Można także użyć skrótu klawiszowego (domyślnie Ctrl-M).
 
-version=0.4.3
-qgisMinimumVersion=2.0
+version=0.5.0
+qgisMinimumVersion=3.22
+qgisMaximumVersion=3.99
 
 # changelog=
 

--- a/newmemorylayerdialog.py
+++ b/newmemorylayerdialog.py
@@ -20,28 +20,29 @@
  ***************************************************************************/
 """
 
-from PyQt4 import QtCore, QtGui
-from ui_newmemorylayer import Ui_NewMemoryLayer
+from qgis.PyQt import QtWidgets
+from .ui_newmemorylayer import Ui_NewMemoryLayer
 
-class NewMemoryLayerDialog(QtGui.QDialog):
+
+class NewMemoryLayerDialog(QtWidgets.QDialog):
     def __init__(self):
-        QtGui.QDialog.__init__(self)
+        QtWidgets.QDialog.__init__(self)
         # Set up the user interface from Designer.
         self.ui = Ui_NewMemoryLayer()
         self.ui.setupUi(self)
         self.geomType = None
-        self.connect(self.ui.butPoint, QtCore.SIGNAL("released()"), self.runPoint)
-        self.connect(self.ui.butLine, QtCore.SIGNAL("released()"), self.runLine)
-        self.connect(self.ui.butPoly, QtCore.SIGNAL("released()"), self.runPoly)
+        self.ui.butPoint.released.connect(self.runPoint)
+        self.ui.butLine.released.connect(self.runLine)
+        self.ui.butPoly.released.connect(self.runPoly)
 
     def runPoint(self):
-        self.geomType = 'Point'
+        self.geomType = "Point"
         self.accept()
 
     def runLine(self):
-        self.geomType = 'LineString'
+        self.geomType = "LineString"
         self.accept()
 
     def runPoly(self):
-        self.geomType = 'Polygon'
+        self.geomType = "Polygon"
         self.accept()

--- a/ui_newmemorylayer.py
+++ b/ui_newmemorylayer.py
@@ -7,65 +7,72 @@
 #
 # WARNING! All changes made in this file will be lost!
 
-from PyQt4 import QtCore, QtGui
+from qgis.PyQt import QtCore, QtWidgets, QtWidgets
 
 try:
     _fromUtf8 = QtCore.QString.fromUtf8
 except AttributeError:
     _fromUtf8 = lambda s: s
 
+
 class Ui_NewMemoryLayer(object):
     def setupUi(self, NewMemoryLayer):
         NewMemoryLayer.setObjectName(_fromUtf8("NewMemoryLayer"))
         NewMemoryLayer.resize(494, 134)
-        self.verticalLayout = QtGui.QVBoxLayout(NewMemoryLayer)
+        self.verticalLayout = QtWidgets.QVBoxLayout(NewMemoryLayer)
         self.verticalLayout.setObjectName(_fromUtf8("verticalLayout"))
-        self.horizontalLayout_2 = QtGui.QHBoxLayout()
+        self.horizontalLayout_2 = QtWidgets.QHBoxLayout()
         self.horizontalLayout_2.setObjectName(_fromUtf8("horizontalLayout_2"))
-        self.label = QtGui.QLabel(NewMemoryLayer)
+        self.label = QtWidgets.QLabel(NewMemoryLayer)
         self.label.setObjectName(_fromUtf8("label"))
         self.horizontalLayout_2.addWidget(self.label)
-        self.leName = QtGui.QLineEdit(NewMemoryLayer)
+        self.leName = QtWidgets.QLineEdit(NewMemoryLayer)
         self.leName.setObjectName(_fromUtf8("leName"))
         self.horizontalLayout_2.addWidget(self.leName)
         self.verticalLayout.addLayout(self.horizontalLayout_2)
-        self.horizontalLayout = QtGui.QHBoxLayout()
+        self.horizontalLayout = QtWidgets.QHBoxLayout()
         self.horizontalLayout.setObjectName(_fromUtf8("horizontalLayout"))
-        self.butPoint = QtGui.QPushButton(NewMemoryLayer)
-        sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Fixed)
+        self.butPoint = QtWidgets.QPushButton(NewMemoryLayer)
+        sizePolicy = QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+        )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.butPoint.sizePolicy().hasHeightForWidth())
         self.butPoint.setSizePolicy(sizePolicy)
         self.butPoint.setObjectName(_fromUtf8("butPoint"))
         self.horizontalLayout.addWidget(self.butPoint)
-        self.butLine = QtGui.QPushButton(NewMemoryLayer)
-        sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Fixed)
+        self.butLine = QtWidgets.QPushButton(NewMemoryLayer)
+        sizePolicy = QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+        )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.butLine.sizePolicy().hasHeightForWidth())
         self.butLine.setSizePolicy(sizePolicy)
         self.butLine.setObjectName(_fromUtf8("butLine"))
         self.horizontalLayout.addWidget(self.butLine)
-        self.butPoly = QtGui.QPushButton(NewMemoryLayer)
-        sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Fixed)
+        self.butPoly = QtWidgets.QPushButton(NewMemoryLayer)
+        sizePolicy = QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+        )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.butPoly.sizePolicy().hasHeightForWidth())
         self.butPoly.setSizePolicy(sizePolicy)
         self.butPoly.setObjectName(_fromUtf8("butPoly"))
         self.horizontalLayout.addWidget(self.butPoly)
-        self.buttonBox = QtGui.QDialogButtonBox(NewMemoryLayer)
+        self.buttonBox = QtWidgets.QDialogButtonBox(NewMemoryLayer)
         self.buttonBox.setOrientation(QtCore.Qt.Horizontal)
-        self.buttonBox.setStandardButtons(QtGui.QDialogButtonBox.Cancel)
+        self.buttonBox.setStandardButtons(QtWidgets.QDialogButtonBox.Cancel)
         self.buttonBox.setObjectName(_fromUtf8("buttonBox"))
         self.horizontalLayout.addWidget(self.buttonBox)
         self.verticalLayout.addLayout(self.horizontalLayout)
         self.label.setBuddy(self.leName)
 
         self.retranslateUi(NewMemoryLayer)
-        QtCore.QObject.connect(self.buttonBox, QtCore.SIGNAL(_fromUtf8("accepted()")), NewMemoryLayer.accept)
-        QtCore.QObject.connect(self.buttonBox, QtCore.SIGNAL(_fromUtf8("rejected()")), NewMemoryLayer.reject)
+        self.buttonBox.accepted.connect(NewMemoryLayer.accept)
+        self.buttonBox.rejected.connect(NewMemoryLayer.reject)
         QtCore.QMetaObject.connectSlotsByName(NewMemoryLayer)
         NewMemoryLayer.setTabOrder(self.leName, self.butPoint)
         NewMemoryLayer.setTabOrder(self.butPoint, self.butLine)
@@ -73,10 +80,29 @@ class Ui_NewMemoryLayer(object):
         NewMemoryLayer.setTabOrder(self.butPoly, self.buttonBox)
 
     def retranslateUi(self, NewMemoryLayer):
-        NewMemoryLayer.setWindowTitle(QtGui.QApplication.translate("NewMemoryLayer", "NewMemoryLayer", None, QtGui.QApplication.UnicodeUTF8))
-        self.label.setText(QtGui.QApplication.translate("NewMemoryLayer", "Name", None, QtGui.QApplication.UnicodeUTF8))
-        self.leName.setText(QtGui.QApplication.translate("NewMemoryLayer", "Memory layer", None, QtGui.QApplication.UnicodeUTF8))
-        self.butPoint.setText(QtGui.QApplication.translate("NewMemoryLayer", "Point", None, QtGui.QApplication.UnicodeUTF8))
-        self.butLine.setText(QtGui.QApplication.translate("NewMemoryLayer", "Line", None, QtGui.QApplication.UnicodeUTF8))
-        self.butPoly.setText(QtGui.QApplication.translate("NewMemoryLayer", "Polygon", None, QtGui.QApplication.UnicodeUTF8))
-
+        NewMemoryLayer.setWindowTitle(
+            QtWidgets.QApplication.translate(
+                "NewMemoryLayer",
+                "NewMemoryLayer",
+                None,
+            )
+        )
+        self.label.setText(
+            QtWidgets.QApplication.translate("NewMemoryLayer", "Name", None)
+        )
+        self.leName.setText(
+            QtWidgets.QApplication.translate(
+                "NewMemoryLayer",
+                "Memory layer",
+                None,
+            )
+        )
+        self.butPoint.setText(
+            QtWidgets.QApplication.translate("NewMemoryLayer", "Point", None)
+        )
+        self.butLine.setText(
+            QtWidgets.QApplication.translate("NewMemoryLayer", "Line", None)
+        )
+        self.butPoly.setText(
+            QtWidgets.QApplication.translate("NewMemoryLayer", "Polygon", None)
+        )


### PR DESCRIPTION
I always found that the step required to created a temporary memory layer was always too long in QGIS.

I was thinking about a new plugin for this and I couldn't find anything when searching in QGIS.

Then I look at the QGIS plugin repository website and I found this plugin but not supported for QGIS 3.x

Instead of creating a new plugin I created this PR to raise again this plugin like a phoenix.

If contribution are welcome, I will see to introduce new PR for QT6 support.