### PR TITLE
Refactoring for other type and plugin simplification

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -41,6 +41,7 @@ experimental=False
 
 # deprecated flag (applies to the whole plugin, not just a single version
 deprecated=False
+supportQt6=True
 
 # Author contact information
 author=Borys Jurgiel

--- a/newmemorylayer.py
+++ b/newmemorylayer.py
@@ -31,6 +31,7 @@ class NewMemoryLayer:
 
     def __init__(self, iface):
         self.iface = iface
+        self.action = None
         # i18n
         pluginPath = QFileInfo(os.path.realpath(__file__)).path()
         localeName = QLocale.system().name()
@@ -47,28 +48,22 @@ class NewMemoryLayer:
             QCoreApplication.translate("NewMemoryLayer", "New Memory Layer..."),
             self.iface.mainWindow(),
         )
-        self.action2 = QAction(
-            QIcon(os.path.join(os.path.dirname(__file__), "layer-memory-create.png")),
-            QCoreApplication.translate("NewMemoryLayer", "New Memory Layer"),
-            self.iface.mainWindow(),
-        )
-        self.iface.registerMainWindowAction(self.action, "Ctrl+M")
+        self.action.setShortcut("Ctrl+W")
+        self.iface.registerMainWindowAction(self.action, "Ctrl+W")
         self.action.triggered.connect(self.run)
-        self.action2.triggered.connect(self.run)
         self.iface.newLayerMenu().addAction(self.action)
-        self.iface.layerToolBar().addAction(self.action2)
+        self.iface.layerToolBar().addAction(self.action)
 
     def unload(self):
-        self.action.triggered.disconnect(self.run)
-        self.action2.triggered.disconnect(self.run)
-        self.iface.unregisterMainWindowAction(self.action)
-        self.iface.newLayerMenu().removeAction(self.action)
-        self.iface.layerToolBar().removeAction(self.action2)
+        if self.action:
+            self.action.triggered.disconnect(self.run)
+            self.iface.unregisterMainWindowAction(self.action)
+            self.iface.newLayerMenu().removeAction(self.action)
 
     def run(self):
         dlg = NewMemoryLayerDialog()
         dlg.show()
-        result = dlg.exec_()
+        result = dlg.exec()
         if result == 1:
             geomType = f"{dlg.geomType}?crs={QgsProject.instance().crs().authid()}"
 

--- a/newmemorylayer.py
+++ b/newmemorylayer.py
@@ -32,6 +32,7 @@ class NewMemoryLayer:
     def __init__(self, iface):
         self.iface = iface
         self.action = None
+        self.dlg = None
         # i18n
         pluginPath = QFileInfo(os.path.realpath(__file__)).path()
         localeName = QLocale.system().name()
@@ -61,11 +62,7 @@ class NewMemoryLayer:
             self.iface.newLayerMenu().removeAction(self.action)
 
     def run(self):
-        dlg = NewMemoryLayerDialog()
-        dlg.show()
-        result = dlg.exec()
-        if result == 1:
-            geomType = f"{dlg.geomType}?crs={QgsProject.instance().crs().authid()}"
-
-            memLay = QgsVectorLayer(geomType, dlg.leName.text(), "memory")
-            QgsProject().instance().addMapLayer(memLay)
+        if not self.dlg:
+            self.dlg = NewMemoryLayerDialog()
+        self.dlg.show()
+        self.dlg.activateWindow()

--- a/newmemorylayer.py
+++ b/newmemorylayer.py
@@ -60,6 +60,7 @@ class NewMemoryLayer:
             self.action.triggered.disconnect(self.run)
             self.iface.unregisterMainWindowAction(self.action)
             self.iface.newLayerMenu().removeAction(self.action)
+            self.iface.layerToolBar().removeAction(self.action)
 
     def run(self):
         if not self.dlg:

--- a/newmemorylayerdialog.py
+++ b/newmemorylayerdialog.py
@@ -41,16 +41,15 @@ class NewMemoryLayerDialog(QtWidgets.QDialog, FORM_CLASS):
         self.setupUi(self)
 
         geom_types = [
-            QgsWkbTypes.Type.NoGeometry,
             QgsWkbTypes.Type.Point,
             QgsWkbTypes.Type.LineString,
-            QgsWkbTypes.Type.CompoundCurve,
             QgsWkbTypes.Type.Polygon,
-            QgsWkbTypes.Type.CurvePolygon,
             QgsWkbTypes.Type.MultiPoint,
             QgsWkbTypes.Type.MultiLineString,
-            QgsWkbTypes.Type.MultiCurve,
             QgsWkbTypes.Type.MultiPolygon,
+            QgsWkbTypes.Type.MultiCurve,
+            QgsWkbTypes.Type.CompoundCurve,
+            QgsWkbTypes.Type.CurvePolygon,
             QgsWkbTypes.Type.MultiSurface,
         ]
 

--- a/newmemorylayerdialog.py
+++ b/newmemorylayerdialog.py
@@ -20,12 +20,14 @@
  ***************************************************************************/
 """
 
+# standard library
 import os
+
+# PyQGIS
 from qgis.PyQt import uic
 from qgis.PyQt import QtWidgets
-
 from qgis.core import QgsWkbTypes, QgsIconUtils, QgsVectorLayer, QgsProject
-
+from qgis.utils import iface
 
 FORM_CLASS = uic.loadUiType(
     os.path.join(os.path.dirname(__file__), "ui_newmemorylayer.ui")
@@ -69,3 +71,8 @@ class NewMemoryLayerDialog(QtWidgets.QDialog, FORM_CLASS):
         geomType = f"{layer_wkb_str}?crs={QgsProject.instance().crs().authid()}"
         memLay = QgsVectorLayer(geomType, self.leName.text(), "memory")
         QgsProject().instance().addMapLayer(memLay)
+
+        if self.chk_start_edition.isChecked():
+            memLay.startEditing()
+            iface.layerTreeView().setCurrentLayer(memLay)
+            iface.actionAddFeature().trigger()

--- a/ui_newmemorylayer.ui
+++ b/ui_newmemorylayer.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>494</width>
-    <height>134</height>
+    <width>499</width>
+    <height>251</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -36,66 +36,22 @@
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QPushButton" name="butPoint">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Point</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="butLine">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Line</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="butPoly">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Polygon</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QDialogButtonBox" name="buttonBox">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel</set>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <layout class="QGridLayout" name="lyt_geometry_types"/>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
  <tabstops>
   <tabstop>leName</tabstop>
-  <tabstop>butPoint</tabstop>
-  <tabstop>butLine</tabstop>
-  <tabstop>butPoly</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/ui_newmemorylayer.ui
+++ b/ui_newmemorylayer.ui
@@ -13,8 +13,28 @@
   <property name="windowTitle">
    <string>NewMemoryLayer</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="3" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QCheckBox" name="chk_start_edition">
+     <property name="text">
+      <string>Start layer edition</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <layout class="QGridLayout" name="lyt_geometry_types"/>
+   </item>
+   <item row="0" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QLabel" name="label">
@@ -34,19 +54,6 @@
       </widget>
      </item>
     </layout>
-   </item>
-   <item>
-    <layout class="QGridLayout" name="lyt_geometry_types"/>
-   </item>
-   <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
-     </property>
-    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
- add support for other type and mutualize code in `NewMemoryLayerDialog`
- add option for layer edition start
- refactor plugin main to use new shortcut "CTRL+W", "CTRL+M" is already used for map creation
- dialog is not closed after layer creation
- add flag for Qt6 support

[Screencast 2025-04-03 09:33:06.webm](https://github.com/user-attachments/assets/293bf45b-2096-4194-b47f-0627974aeada)

