### PR TITLE
Add a toolbar with shortcuts to create layers for the three main geometry types (point, line, polygon) with a single click.

### DIFF
--- a/newmemorylayer.py
+++ b/newmemorylayer.py
@@ -22,13 +22,14 @@
 from qgis.PyQt.QtCore import *
 from qgis.PyQt.QtGui import *
 from qgis.core import *
-
+from qgis.core import QgsWkbTypes
 from .newmemorylayerdialog import NewMemoryLayerDialog
 import os
+from qgis.PyQt.QtWidgets import QToolBar
+from typing import Optional
 
 
 class NewMemoryLayer:
-
     def __init__(self, iface):
         self.iface = iface
         self.action = None
@@ -42,6 +43,7 @@ class NewMemoryLayer:
             self.translator = QTranslator()
             self.translator.load(self.localePath)
             QCoreApplication.installTranslator(self.translator)
+        self.toolbar: Optional[QToolBar] = None
 
     def initGui(self):
         self.action = QAction(
@@ -55,12 +57,58 @@ class NewMemoryLayer:
         self.iface.newLayerMenu().addAction(self.action)
         self.iface.layerToolBar().addAction(self.action)
 
+        # Toolbar
+        if self.toolbar is None:
+            self.toolbar = QToolBar("NewMemoryLayerToolbar", self.iface.mainWindow())
+            self.toolbar.setObjectName("NewMemoryLayerToolbar")
+            self.iface.addToolBar(self.toolbar)
+
+        # Add action Point / Line / Polygon
+        self._add_layer_action(
+            ":images/themes/default/mIconPointLayer.svg",
+            "Add new point layer",
+            "Add new point layer...",
+            QgsWkbTypes.Type.Point,
+            "Point",
+        )
+
+        self._add_layer_action(
+            ":images/themes/default/mIconLineLayer.svg",
+            "Add new line layer",
+            "Add new line layer...",
+            QgsWkbTypes.Type.LineString,
+            "Line",
+        )
+
+        self._add_layer_action(
+            ":images/themes/default/mIconPolygonLayer.svg",
+            "Add new polygon layer",
+            "Add new polygon layer...",
+            QgsWkbTypes.Type.Polygon,
+            "Polygon",
+        )
+
+    def _add_layer_action(self, icon_path, context, text, wkb_type, label):
+        action = QAction(
+            QIcon(icon_path),
+            QCoreApplication.translate(context, text),
+            self.iface.mainWindow(),
+        )
+        action.triggered.connect(
+            lambda: NewMemoryLayerDialog().generic_add_layer(wkb_type, label, False)
+        )
+        self.toolbar.addAction(action)
+
     def unload(self):
         if self.action:
             self.action.triggered.disconnect(self.run)
             self.iface.unregisterMainWindowAction(self.action)
             self.iface.newLayerMenu().removeAction(self.action)
             self.iface.layerToolBar().removeAction(self.action)
+
+        # remove toolbar :
+        if self.toolbar:
+            self.toolbar.deleteLater()
 
     def run(self):
         if not self.dlg:

--- a/newmemorylayerdialog.py
+++ b/newmemorylayerdialog.py
@@ -65,13 +65,21 @@ class NewMemoryLayerDialog(QtWidgets.QDialog, FORM_CLASS):
             button.clicked.connect(lambda clicked, t=geom_type: self.add_layer(t))
             self.lyt_geometry_types.addWidget(button, row, col)
 
-    def add_layer(self, geom_type: QgsWkbTypes.Type):
+    def add_layer(self, geom_type):
+        self.generic_add_layer(
+            geom_type, self.leName.text(), self.chk_start_edition.isChecked()
+        )
+
+    @classmethod
+    def generic_add_layer(
+        self, geom_type: QgsWkbTypes.Type, name: str = None, edit: bool = False
+    ):
         layer_wkb_str = QgsWkbTypes.displayString(geom_type)
         geomType = f"{layer_wkb_str}?crs={QgsProject.instance().crs().authid()}"
-        memLay = QgsVectorLayer(geomType, self.leName.text(), "memory")
+        memLay = QgsVectorLayer(geomType, name, "memory")
         QgsProject().instance().addMapLayer(memLay)
 
-        if self.chk_start_edition.isChecked():
+        if edit:
             memLay.startEditing()
             iface.layerTreeView().setCurrentLayer(memLay)
             iface.actionAddFeature().trigger()


### PR DESCRIPTION
Hello @borysiasty and thank you for your handy plugin. 

I'd like to suggest an evolution: I'd like to create a temporary layer with just one click. So as not to overload the interface, I'm proposing this only for the three basic types: Point, Line and Polygon.

Video: 


https://github.com/user-attachments/assets/420cd39f-ea86-41ce-a0ac-e91fcd5435c0



ping @jmkerloch